### PR TITLE
validation rules for 'documentation' property added; test specs setup…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,64 @@ class ServerlessAWSDocumentation {
             },
         }
     };
+
+    //validation rules for 'documentation' property on 'http' event from 'aws' provider
+    const docConfigSchema = {
+      type: 'object',
+      definitions: {
+        models: {
+          type: 'object',
+          patternProperties: { '*/*': { type: 'string' } }
+        },
+        body: {
+          type: 'object',
+          properties: { description: { type: 'string' } }
+        },
+        arrayOfProps: {
+          type: 'array',
+          items: [
+            {
+              type: 'object',
+              properties: { name: { type: 'string' }, description: { type: 'string' } },
+              required: [ 'name' ]
+            }
+          ]
+        }
+      },
+      properties: {
+        documentation: {
+          type: 'object',
+          properties: {
+            summary: { type: 'string' },
+            description: { type: 'string' },
+            tags: { type: 'array', items: [ { type: 'string' } ] },
+            requestBody: { "'$ref'": '#/definitions/body' },
+            requestHeaders: { "'$ref'": '#/definitions/arrayOfProps' },
+            queryParams: { "'$ref'": '#/definitions/arrayOfProps' },
+            pathParams: { "'$ref'": '#/definitions/arrayOfProps' },
+            requestModels: { "'$ref'": '#/definitions/models' },
+            methodResponses: {
+              type: 'array',
+              items: [
+                {
+                  type: 'object',
+                  properties: {
+                    statusCode: { type: 'number' },
+                    responseBody: { "'$ref'": '#/definitions/body' },
+                    responseHeaders: { "'$ref'": '#/definitions/arrayOfProps' },
+                    responseModels: { "'$ref'": '#/definitions/models' }
+                  },
+                  required: [ 'statusCode' ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    };
+    
+    //create schema for 'documentation' property
+    this.serverless.configSchemaHandler.defineFunctionEventProperties('aws', 'http', docConfigSchema);
   }
 
   beforeDeploy() {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -57,6 +57,9 @@ describe('ServerlessAWSDocumentation', function () {
           }
         }
       },
+      configSchemaHandler: {
+        defineFunctionEventProperties: jasmine.createSpy('define function event props')
+      },
     };
 
     this.serverlessMock.providers.aws.naming.getMethodLogicalId.and.callFake((resourcename, method) => {


### PR DESCRIPTION
The Serverless Framework has added http event validation since version 2.6.0 without including 'documentation' property. Plugin developers are encouraged to extend validation schema by adding validation rules for additional properties supported by plugin.

This PR resolves "Unrecognized property 'documentation'" triggered by serverless framework (since version 2.6.0) by adding JSON schema definition for 'documentation' property inside 'serverless-aws-plugin' constructor.