### PR TITLE
Remove error raised by Serverless Framework on http event StatusCode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ class ServerlessAWSDocumentation {
                 {
                   type: 'object',
                   properties: {
-                    statusCode: { type: 'number' },
+                    statusCode: { type: 'string' },
                     responseBody: { "'$ref'": '#/definitions/body' },
                     responseHeaders: { "'$ref'": '#/definitions/arrayOfProps' },
                     responseModels: { "'$ref'": '#/definitions/models' }


### PR DESCRIPTION
Once service has been deployed the following error is raised by Serverless Framework:
**Expected params.location.statusCode to be a string**

I fixed this issue by changing StatusCode to be 'string' instead 'number'