### PR TITLE
Add --exportType argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,10 @@ See the Serverless documentation for more information on [resource naming](https
 
 To download the deployed documentation you just need to use `serverless downloadDocumentation --outputFileName=filename.ext`.
 For `yml` or `yaml` extensions application/yaml content will be downloaded from AWS. In any other case - application/json.
+
 Optional argument --extensions ['integrations', 'apigateway', 'authorizers', 'postman']. Defaults to 'integrations'.
+
+Optional argument --exportType ['oas30', 'swagger']. Defaults to 'swagger'.
 
 ## Contribution
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kakkuk/serverless-aws-apigateway-documentation",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
   "main": "src/index.js",
   "scripts": {

--- a/src/downloadDocumentation.js
+++ b/src/downloadDocumentation.js
@@ -8,7 +8,7 @@ module.exports = {
       return aws.request('APIGateway', 'getExport', {
         stageName: aws.getStage(),
         restApiId: restApiId,
-        exportType: 'swagger',
+        exportType: exportType(this.options.exportType),
         parameters: {
           extensions: extensionType(this.options.extensions),
         },
@@ -47,6 +47,10 @@ function createAWSContentType(outputFileName) {
   }
 
   return awsContentType;
+}
+
+function exportType(exportArg) {
+  return ['swagger', 'oas30'].includes(exportArg) ? exportArg : 'swagger';
 }
 
 function extensionType(extensionArg) {

--- a/src/downloadDocumentation.spec.js
+++ b/src/downloadDocumentation.spec.js
@@ -87,6 +87,91 @@ describe('ServerlessAWSDocumentation', function () {
       });
     });
 
+    it('should successfully download documentation, defaulting exportType argument to "swagger" when not specified', (done) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.json',
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId');
+      };
+
+      objectUnderTest.serverless.providers.aws.request.and.returnValue(Promise.resolve({
+        body: 'some body',
+      }));
+      return objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'swagger',
+          parameters: {
+            extensions: 'integrations',
+          },
+          accepts: 'application/json',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+
+        done();
+      });
+    });
+
+    it('should successfully download documentation, defaulting exportType argument to "swagger" when specified incorrectly', (done) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.json',
+        exportType: 'xml',
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId');
+      };
+
+      objectUnderTest.serverless.providers.aws.request.and.returnValue(Promise.resolve({
+        body: 'some body',
+      }));
+      return objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'swagger',
+          parameters: {
+            extensions: 'integrations',
+          },
+          accepts: 'application/json',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+
+        done();
+      });
+    });
+
+    it('should successfully download documentation, using specified exportType argument', (done) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.json',
+        exportType: 'oas30',
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId');
+      };
+
+      objectUnderTest.serverless.providers.aws.request.and.returnValue(
+        Promise.resolve({
+          body: 'some body',
+        })
+      );
+      return objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'oas30',
+          parameters: {
+            extensions: 'integrations',
+          },
+          accepts: 'application/json',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+
+        done();
+      });
+    });
+
     it('should successfully download documentation, yaml extension, using an extensions argument', (done) => {
       objectUnderTest.options = {
         outputFileName: 'test.yml',

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,10 @@ class ServerlessAWSDocumentation {
                     required: false,
                     type: 'multiple'
                 },
+                exportType: {
+                    required: false,
+                    type: 'string',
+                },
             },
         }
     };


### PR DESCRIPTION
Hi team 👋🏼 

This is a small PR to allow the user to specify the exported documentation format via an `--exportType` argument

 Acceptable values are `oas30` for OpenAPI 3.0.x and `swagger` for Swagger/OpenAPI 2.0 [as per AWS Docs](https://docs.aws.amazon.com/cli/latest/reference/apigateway/get-export.html#options)

Using `oas30` instead of `swagger` fixes some issues in the docs, for example: it correctly displays `allOf` and `oneOf` schemas and it fixes an issue where swagger incorrectly parses `options` endpoints responses

Please let me know if you are happy for this to be merged to or if you'd like me to make further changes!