### PR TITLE
Minor: Add OpenAPI 3.0 support for serverless downloadDocumentation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,13 @@ See the Serverless documentation for more information on [resource naming](https
 ### Download documentation from AWS API Gateway
 
 To download the deployed documentation you just need to use `serverless downloadDocumentation --outputFileName=filename.ext`.
-For `yml` or `yaml` extensions application/yaml content will be downloaded from AWS. In any other case - application/json.
+
+By default, the documentation will be downloaded in JSON format (content-type: application/json).
+To download it in YAML format (content-type: application/yaml), simply use `yml` or `yaml` extension in the "outputFileName" argument: `serverless downloadDocumentation --outputFileName=filename.yml`
+
+By default, the documentation will be downloaded in OpenAPI 2.0 (Swagger).
+To download it in OpenAPI 3.0, use `oas30` or `openapi30` type in the "exportType" argument: `serverless downloadDocumentation --outputFileName=filename.ext --exportType oas30`
+
 Optional argument --extensions ['integrations', 'apigateway', 'authorizers', 'postman']. Defaults to 'integrations'.
 
 ## Contribution

--- a/src/downloadDocumentation.js
+++ b/src/downloadDocumentation.js
@@ -8,7 +8,7 @@ module.exports = {
       return aws.request('APIGateway', 'getExport', {
         stageName: aws.getStage(),
         restApiId: restApiId,
-        exportType: 'swagger',
+        exportType: exportType(this.options.exportType),
         parameters: {
           extensions: extensionType(this.options.extensions),
         },
@@ -57,5 +57,14 @@ function extensionType(extensionArg) {
   } else {
     return 'integrations';
   }
+}
+
+function exportType(exportTypeArg) {
+  let awsExportType = 'swagger';
+  if (exportTypeArg === 'oas30' || exportTypeArg === 'openapi30') {
+    awsExportType = 'oas30';
+  }
+
+  return awsExportType;
 }
 

--- a/src/downloadDocumentation.spec.js
+++ b/src/downloadDocumentation.spec.js
@@ -59,9 +59,10 @@ describe('ServerlessAWSDocumentation', function () {
       });
     });
 
-    it('should successfully download documentation, yaml extension', async () => {
+    it.each([['yml'], ['yaml']])('should successfully download documentation, %s extension', async (outputFileExtension) => {
+      const outputFileName = `test.${outputFileExtension}`;
       objectUnderTest.options = {
-        outputFileName: 'test.yml',
+        outputFileName: outputFileName,
       };
       objectUnderTest._getRestApiId = () => {
         return Promise.resolve('testRestApiId')
@@ -80,7 +81,59 @@ describe('ServerlessAWSDocumentation', function () {
           },
           accepts: 'application/yaml',
         });
-        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.yml', 'some body');
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith(outputFileName, 'some body');
+      });
+    });
+
+    it('should successfully download documentation, json extension, using unknown export type', async () => {
+      objectUnderTest.options = {
+        outputFileName: 'test.json',
+        exportType: 'graphql'
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId')
+      };
+
+      objectUnderTest.serverless.providers.aws.request.mockReturnValue(Promise.resolve({
+        body: 'some body',
+      }));
+      await objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'swagger',
+          parameters: {
+            extensions: 'integrations',
+          },
+          accepts: 'application/json',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+      });
+    });
+
+    it.each([['oas30'], ['openapi30']])('should successfully download documentation, json extension, using %s export type', async (exportType) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.json',
+        exportType: exportType
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId')
+      };
+
+      objectUnderTest.serverless.providers.aws.request.mockReturnValue(Promise.resolve({
+        body: 'some body',
+      }));
+      await objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'oas30',
+          parameters: {
+            extensions: 'integrations',
+          },
+          accepts: 'application/json',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
       });
     });
 

--- a/src/downloadDocumentation.spec.js
+++ b/src/downloadDocumentation.spec.js
@@ -41,22 +41,22 @@ describe('ServerlessAWSDocumentation', function () {
       objectUnderTest._getRestApiId = () => {
         return Promise.resolve('testRestApiId')
       };
-
       objectUnderTest.serverless.providers.aws.request.mockReturnValue(Promise.resolve({
         body: 'some body',
       }));
-      await objectUnderTest.downloadDocumentation().then(() => {
-        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
-          stageName: 'testStage',
-          restApiId: 'testRestApiId',
-          exportType: 'swagger',
-          parameters: {
-            extensions: 'integrations',
-          },
-          accepts: 'application/json',
-        });
-        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.txt', 'some body');
+
+      await objectUnderTest.downloadDocumentation();
+
+      expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+        stageName: 'testStage',
+        restApiId: 'testRestApiId',
+        exportType: 'swagger',
+        parameters: {
+          extensions: 'integrations',
+        },
+        accepts: 'application/json',
       });
+      expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.txt', 'some body');
     });
 
     it.each([['yml'], ['yaml']])('should successfully download documentation, %s extension', async (outputFileExtension) => {
@@ -67,22 +67,22 @@ describe('ServerlessAWSDocumentation', function () {
       objectUnderTest._getRestApiId = () => {
         return Promise.resolve('testRestApiId')
       };
-
       objectUnderTest.serverless.providers.aws.request.mockReturnValue(Promise.resolve({
         body: 'some body',
       }));
-      await objectUnderTest.downloadDocumentation().then(() => {
-        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
-          stageName: 'testStage',
-          restApiId: 'testRestApiId',
-          exportType: 'swagger',
-          parameters: {
-            extensions: 'integrations',
-          },
-          accepts: 'application/yaml',
-        });
-        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith(outputFileName, 'some body');
+
+      await objectUnderTest.downloadDocumentation();
+
+      expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+        stageName: 'testStage',
+        restApiId: 'testRestApiId',
+        exportType: 'swagger',
+        parameters: {
+          extensions: 'integrations',
+        },
+        accepts: 'application/yaml',
       });
+      expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith(outputFileName, 'some body');
     });
 
     it('should successfully download documentation, json extension, using unknown export type', async () => {
@@ -93,22 +93,22 @@ describe('ServerlessAWSDocumentation', function () {
       objectUnderTest._getRestApiId = () => {
         return Promise.resolve('testRestApiId')
       };
-
       objectUnderTest.serverless.providers.aws.request.mockReturnValue(Promise.resolve({
         body: 'some body',
       }));
-      await objectUnderTest.downloadDocumentation().then(() => {
-        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
-          stageName: 'testStage',
-          restApiId: 'testRestApiId',
-          exportType: 'swagger',
-          parameters: {
-            extensions: 'integrations',
-          },
-          accepts: 'application/json',
-        });
-        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+
+      await objectUnderTest.downloadDocumentation();
+
+      expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+        stageName: 'testStage',
+        restApiId: 'testRestApiId',
+        exportType: 'swagger',
+        parameters: {
+          extensions: 'integrations',
+        },
+        accepts: 'application/json',
       });
+      expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
     });
 
     it.each([['oas30'], ['openapi30']])('should successfully download documentation, json extension, using %s export type', async (exportType) => {
@@ -119,22 +119,22 @@ describe('ServerlessAWSDocumentation', function () {
       objectUnderTest._getRestApiId = () => {
         return Promise.resolve('testRestApiId')
       };
-
       objectUnderTest.serverless.providers.aws.request.mockReturnValue(Promise.resolve({
         body: 'some body',
       }));
-      await objectUnderTest.downloadDocumentation().then(() => {
-        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
-          stageName: 'testStage',
-          restApiId: 'testRestApiId',
-          exportType: 'oas30',
-          parameters: {
-            extensions: 'integrations',
-          },
-          accepts: 'application/json',
-        });
-        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+
+      await objectUnderTest.downloadDocumentation();
+
+      expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+        stageName: 'testStage',
+        restApiId: 'testRestApiId',
+        exportType: 'oas30',
+        parameters: {
+          extensions: 'integrations',
+        },
+        accepts: 'application/json',
       });
+      expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
     });
 
     it('should successfully download documentation, yaml extension, using an extensions argument', async () => {
@@ -145,22 +145,22 @@ describe('ServerlessAWSDocumentation', function () {
       objectUnderTest._getRestApiId = () => {
         return Promise.resolve('testRestApiId')
       };
-
       objectUnderTest.serverless.providers.aws.request.mockReturnValue(Promise.resolve({
         body: 'some body',
       }));
-      await objectUnderTest.downloadDocumentation().then(() => {
-        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
-          stageName: 'testStage',
-          restApiId: 'testRestApiId',
-          exportType: 'swagger',
-          parameters: {
-            extensions: 'apigateway',
-          },
-          accepts: 'application/yaml',
-        });
-        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.yml', 'some body');
+
+      await objectUnderTest.downloadDocumentation();
+
+      expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+        stageName: 'testStage',
+        restApiId: 'testRestApiId',
+        exportType: 'swagger',
+        parameters: {
+          extensions: 'apigateway',
+        },
+        accepts: 'application/yaml',
       });
+      expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.yml', 'some body');
     });
 
     it('should throw an error', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,10 @@ class ServerlessAWSDocumentation {
                   required: true,
                   type: 'string'
                 },
+                exportType: {
+                    required: false,
+                    type: 'string'
+                },
                 extensions: {
                     required: false,
                     type: 'multiple'


### PR DESCRIPTION
The `serverless downloadDocumentation` command currently supports to download the documentation only in OpenAPI 2.0 (Swagger).
This pull request adds support to (optionally) download the documentation also in OpenAPI 3.0.

Example:
```
$ serverless downloadDocumentation --outputFileName=filename.ext --exportType oas30
```

See also: https://github.com/failsafe-engineering/serverless-aws-apigateway-documentation/issues/40